### PR TITLE
fix: fix for automatic HEAD routes

### DIFF
--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -31,6 +31,10 @@ module.exports = class ValidatorDictionary {
           [httpPart]: validator
         }
       }
+    } else if (this[kSchemas][path][method] == null) {
+      this[kSchemas][path][method] = {
+        [httpPart]: validator
+      }
     } else {
       this[kSchemas][path][method][httpPart] = validator
     }


### PR DESCRIPTION
Fastify 4 creates sibling HEAD routes for GET routes by default. 
https://www.fastify.io/docs/latest/Guides/Migration-Guide-V4/#exposeheadroutes-true-by-default

This causes an error in the split validator when the path exists (via GET) but the HEAD method does not. 

This fix covers that case.